### PR TITLE
Update CI badge on README

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test aprotyas.github.io
+name: Build aprotyas.github.io
 
 on: [push, pull_request]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aprotyas.github.io
 
-[![Build Status](https://travis-ci.com/aprotyas/aprotyas.github.io.svg?branch=master)](https://travis-ci.com/aprotyas/aprotyas.github.io)
+[![Build Status](https://github.com/aprotyas/aprotyas.github.io/actions/workflows/test.yml/badge.svg)](https://github.com/aprotyas/aprotyas.github.io/actions/workflows/test.yml)
 
 Forked from [academicpages](https://academicpages.github.io/). Removed a bunch
 of stuff since I am not an academician.


### PR DESCRIPTION
Previously, the build badge was from artifacts in Travis CI's infrastructure.

Signed-off-by: aprotyas <aprotyas@u.rochester.edu>